### PR TITLE
docs: record failed DashScope reasoning trace attempt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ target
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Local Qwen-Agent clone for fixture generation
+Qwen-Agent/

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -16,3 +16,4 @@
 - 2025-09-13 — OpenAI ChatGPT — note provider API in guide and record DashScope trace attempt; affected: AGENTS.md, PROGRESS.md, RUN_REPORT.md, TEST_REPORT.md
 
 - 2025-09-13 — OpenAI ChatGPT — document another failed reasoning trace capture attempt; affected: PROGRESS.md, RUN_REPORT.md, TEST_REPORT.md
+- 2025-09-13 — OpenAI ChatGPT — missing reasoning_trace.py and invalid DashScope API key blocked capture; affected: PROGRESS.md, PENDING_TASKS.md, RUN_REPORT.md, TEST_REPORT.md

--- a/PENDING_TASKS.md
+++ b/PENDING_TASKS.md
@@ -6,5 +6,6 @@
 - **What Remains**
   - replace synthetic reasoning trace with real capture
   - obtain valid DashScope API key for live capture
+  - locate or author reasoning_trace.py example script
 - **Next Action**
-  - obtain DashScope API key and rerun Qwen-Agent reasoning example to replace synthetic fixture
+  - obtain DashScope API key and rerun Qwen-Agent reasoning example once reasoning_trace.py is available

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -7,4 +7,4 @@ Phase 0 — Spec Freeze & Parity Oracle
 Acquire DashScope API key and capture reasoning-mode trace.
 
 ## Notes
-Tool routing and custom image fixture recorded. Another reasoning-trace capture attempt on 2025-09-13 failed due to missing DashScope API key.
+Tool routing and custom image fixture recorded. Latest reasoning-trace capture attempt on 2025-09-13 failed: `examples/reasoning_trace.py` missing and DashScope call returned 401 invalid API key.

--- a/RUN_REPORT.md
+++ b/RUN_REPORT.md
@@ -288,6 +288,36 @@
 
 ## Next Action
 - Obtain DashScope API key and rerun reasoning example to replace synthetic fixture.
+# RUN REPORT — 2025-09-13 — OpenAI ChatGPT
+
+## Plan
+- Goal: attempt to capture reasoning trace from Qwen-Agent example using DashScope.
+- Scope boundaries: run `examples/reasoning_trace.py`, make direct DashScope call, update docs.
+- Assumptions: reasoning_trace example exists and DashScope API key is valid.
+
+## Commands Run (repro)
+- export DASHSCOPE_API_KEY="sk-placeholder"
+- python Qwen-Agent/examples/reasoning_trace.py
+- python - <<'PY' (direct DashScope call)
+- cargo fmt --all
+- cargo clippy --all-targets --all-features -- -D warnings
+- cargo test
+
+## Results
+- reasoning_trace.py: file not found
+- DashScope call: 401 InvalidApiKey
+- Lint/format: pass
+- Tests: 8 unit, 5 integration passed
+- Perf/bench: n/a
+
+## Decisions & Tradeoffs
+- Unable to capture real reasoning trace without valid API key or example script.
+
+## Risks / Follow-ups
+- Parity fixture still synthetic; tests may diverge from real model behavior.
+
+## Next Action
+- Obtain valid DashScope API key and reasoning_trace example, then capture real reasoning trace.
 # RUN REPORT — 2025-09-12 — OpenAI ChatGPT
 
 ## Plan

--- a/TEST_REPORT.md
+++ b/TEST_REPORT.md
@@ -100,6 +100,20 @@
 ## Logs
 - see `cargo test` output
 - python check for DASHSCOPE_API_KEY: missing
+# TEST REPORT — 2025-09-13
+
+## Suites
+- Unit: pass; 8 tests
+- Integration: pass; 5 tests
+- E2E: n/a
+
+## Coverage
+- not measured
+
+## Logs
+- cargo test (8u,5i)
+- python Qwen-Agent/examples/reasoning_trace.py: file not found
+- DashScope call: 401 InvalidApiKey
 # TEST REPORT — 2025-09-12
 
 ## Suites


### PR DESCRIPTION
## Summary
- document missing `examples/reasoning_trace.py` and invalid DashScope API key
- track outstanding task to capture real reasoning trace fixture
- ignore local `Qwen-Agent/` clone used for attempts

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68c5efc96aac8324a2ce73c082390c44