### PR TITLE
feat: add MCP client and provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,8 @@ Provide a portable Rust agent runtime mirroring Qwen-Agent behaviors.
 - Added HTTP backend provider using `HttpConfig { base_url, model, api_key, timeout }` that maps universal tool schemas,
   `tool_choice`, and reasoning flags to provider-specific fields (`tools`/`functions`, `tool_choice`/`function_call`,
   `reasoning`/`enable_chain_of_thought`).
+- Added `mcp_client` crate and `McpProvider` for JSON-RPC servers.
+- `Agent::register_tool` now accepts MCP endpoints or JSON config files via `ToolSpec`.
 
 ## HTTP Backend Usage
 ```rust
@@ -60,6 +62,24 @@ let reply = provider.ask(ask);
 ```
 Set `dialect` to `"dashscope"` in the context to emit DashScope field names
 (`functions`, `function_call`, `enable_chain_of_thought`).
+
+## MCP Server Configuration
+
+Create a JSON file mapping tool names to MCP server URLs:
+
+```json
+{ "ping": "http://localhost:8080/" }
+```
+
+Register tools from the file:
+
+```rust
+use soma_agent::{Agent, ToolSpec};
+use tokio_util::sync::CancellationToken;
+
+let mut agent = Agent::new(provider, 1, 1000, 1, CancellationToken::new());
+agent.register_tool("cfg", ToolSpec::McpConfigFile("tools.json".into())).unwrap();
+```
 
 ## Phased Plan
 1) Phase 0 — Spec Freeze & Parity Oracle

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -20,3 +20,4 @@
 - 2025-09-13 — OpenAI ChatGPT — add parallel tool call execution and tests; affected: src/lib.rs, tests/parity_fixture.rs, Cargo.toml, AGENTS.md, PROGRESS.md, RUN_REPORT.md, TEST_REPORT.md, CHANGE_LOG.md
 - 2025-09-14 — OpenAI ChatGPT — add retry and cancellation with exponential backoff; affected: src/lib.rs, tests/parity_fixture.rs, Cargo.toml, AGENTS.md, PROGRESS.md, RUN_REPORT.md, TEST_REPORT.md
 - 2025-09-14 — OpenAI ChatGPT — add HTTP chat completions backend with dialect-aware tool and reasoning mapping; affected: Cargo.toml, src/backends/http.rs, src/backends/mod.rs, src/lib.rs, tests/http_backend.rs, AGENTS.md, PROGRESS.md, RUN_REPORT.md, TEST_REPORT.md
+- 2025-09-14 — OpenAI ChatGPT — add MCP client crate, provider, config registration, and docs; affected: mcp_client/**, src/mcp/mod.rs, src/lib.rs, tests/mcp_integration.rs, AGENTS.md, PROGRESS.md, RUN_REPORT.md, TEST_REPORT.md, Cargo.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1137,6 +1137,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "mcp_client"
+version = "0.1.0"
+dependencies = [
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1726,6 +1736,7 @@ name = "soma_agent"
 version = "0.1.0"
 dependencies = [
  "httpmock",
+ "mcp_client",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ serde_json = "1.0.143"
 tokio = { version = "1.40.0", features = ["macros", "rt-multi-thread", "time"] }
 tokio-util = { version = "0.7.11" }
 reqwest = { version = "0.12.4", features = ["blocking", "json"] }
+mcp_client = { path = "mcp_client" }
 
 [dev-dependencies]
 httpmock = "0.7.0"

--- a/PROGRESS.md
+++ b/PROGRESS.md
@@ -7,4 +7,4 @@ None
 None
 
 ## Notes
-Added HTTP backend provider and tests.
+Integrated MCP client and provider with config registration.

--- a/RUN_REPORT.md
+++ b/RUN_REPORT.md
@@ -314,6 +314,33 @@
 
 ## Next Action
 - None
+
+# RUN REPORT — 2025-09-14 — OpenAI ChatGPT
+
+## Plan
+- Goal: add MCP client and provider, allow Agent to register MCP tools from config, and document usage.
+- Scope boundaries: new `mcp_client` crate, `McpProvider`, Agent registration, tests, docs.
+- Assumptions: JSON-RPC over HTTP; blocking reqwest acceptable.
+
+## Commands Run (repro)
+- cargo fmt --all
+- cargo clippy --all-targets --all-features -- -D warnings
+- cargo test
+
+## Results
+- Lint/format: pass
+- Tests: 9 unit, 8 integration passed
+- Perf/bench: n/a
+
+## Decisions & Tradeoffs
+- Blocking JSON-RPC client favors simplicity over async performance.
+
+## Risks / Follow-ups
+- MCP client lacks auth and streaming; future work may add both.
+
+## Next Action
+- None
+
 # RUN REPORT — 2025-09-13 — OpenAI ChatGPT
 
 ## Plan

--- a/TEST_REPORT.md
+++ b/TEST_REPORT.md
@@ -191,3 +191,15 @@
 
 ## Logs
 - see `cargo test` output
+# TEST REPORT — 2025-09-14
+
+## Suites
+- Unit: pass; 9 tests
+- Integration: pass; 8 tests
+- E2E: n/a
+
+## Coverage
+- not measured
+
+## Logs
+- see `cargo test` output

--- a/mcp_client/Cargo.toml
+++ b/mcp_client/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "mcp_client"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0.143"
+reqwest = { version = "0.12.4", features = ["blocking", "json"] }
+thiserror = "1.0.61"

--- a/mcp_client/src/lib.rs
+++ b/mcp_client/src/lib.rs
@@ -1,0 +1,79 @@
+use reqwest::blocking::Client;
+use serde_json::{json, Value};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("transport: {0}")]
+    Transport(#[from] reqwest::Error),
+    #[error("rpc error: {0}")]
+    Rpc(Value),
+}
+
+pub struct McpClient {
+    base_url: String,
+    http: Client,
+    id: AtomicU64,
+}
+
+impl McpClient {
+    pub fn new(base_url: impl Into<String>) -> Result<Self, Error> {
+        let client = Client::new();
+        let this = Self {
+            base_url: base_url.into(),
+            http: client,
+            id: AtomicU64::new(1),
+        };
+        // Perform handshake to ensure server is reachable
+        let _ = this.handshake()?;
+        Ok(this)
+    }
+
+    fn rpc(&self, method: &str, params: Value) -> Result<Value, Error> {
+        let id = self.id.fetch_add(1, Ordering::SeqCst);
+        let req = json!({"jsonrpc":"2.0","id":id,"method":method,"params":params});
+        let resp: Value = self.http.post(&self.base_url).json(&req).send()?.json()?;
+        if let Some(err) = resp.get("error") {
+            return Err(Error::Rpc(err.clone()));
+        }
+        Ok(resp["result"].clone())
+    }
+
+    pub fn handshake(&self) -> Result<Value, Error> {
+        self.rpc("handshake", json!({}))
+    }
+
+    pub fn schema(&self, tool: &str) -> Result<Value, Error> {
+        self.rpc("schema", json!({"tool": tool}))
+    }
+
+    pub fn invoke(&self, tool: &str, input: Value) -> Result<Value, Error> {
+        self.rpc("invoke", json!({"tool": tool, "input": input}))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use httpmock::prelude::*;
+
+    #[test]
+    fn client_invokes() {
+        let server = MockServer::start();
+        let _handshake = server.mock(|when, then| {
+            when.method(POST)
+                .json_partial(json!({"method":"handshake"}));
+            then.status(200)
+                .json_body(json!({"jsonrpc":"2.0","id":1,"result":{"ok":true}}));
+        });
+        let _invoke = server.mock(|when, then| {
+            when.method(POST).json_partial(json!({"method":"invoke"}));
+            then.status(200)
+                .json_body(json!({"jsonrpc":"2.0","id":2,"result":{"pong":true}}));
+        });
+
+        let client = McpClient::new(server.url("/")).unwrap();
+        let out = client.invoke("ping", json!({})).unwrap();
+        assert_eq!(out, json!({"pong":true}));
+    }
+}

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1,0 +1,55 @@
+use std::collections::HashMap;
+use std::sync::Mutex;
+use std::time::Instant;
+
+use serde_json::{json, Value};
+
+use crate::{Ask, Provider, ProviderKind, Reply};
+use mcp_client::{Error as McpError, McpClient};
+
+pub struct McpProvider {
+    client: McpClient,
+    schemas: Mutex<HashMap<String, Value>>,
+}
+
+impl McpProvider {
+    pub fn new(url: impl Into<String>) -> Result<Self, McpError> {
+        let client = McpClient::new(url.into())?;
+        Ok(Self {
+            client,
+            schemas: Mutex::new(HashMap::new()),
+        })
+    }
+}
+
+impl Provider for McpProvider {
+    fn kind(&self) -> ProviderKind {
+        ProviderKind::RemoteGrpc
+    }
+
+    fn ask(&self, ask: Ask) -> Reply {
+        let start = Instant::now();
+        {
+            let mut schemas = self.schemas.lock().unwrap();
+            if !schemas.contains_key(&ask.op) {
+                if let Ok(schema) = self.client.schema(&ask.op) {
+                    schemas.insert(ask.op.clone(), schema);
+                }
+            }
+        }
+        match self.client.invoke(&ask.op, ask.input.clone()) {
+            Ok(out) => Reply {
+                ok: true,
+                output: out,
+                latency_ms: start.elapsed().as_millis() as u64,
+                cost: json!({}),
+            },
+            Err(e) => Reply {
+                ok: false,
+                output: json!({"error": e.to_string()}),
+                latency_ms: start.elapsed().as_millis() as u64,
+                cost: json!({}),
+            },
+        }
+    }
+}

--- a/tests/mcp_integration.rs
+++ b/tests/mcp_integration.rs
@@ -1,0 +1,70 @@
+use httpmock::prelude::*;
+use serde_json::json;
+use tokio_util::sync::CancellationToken;
+
+use soma_agent::{Agent, Ask, Provider, ProviderKind, Reply, ToolSpec};
+
+struct Dummy;
+
+impl Provider for Dummy {
+    fn kind(&self) -> ProviderKind {
+        ProviderKind::Embedded
+    }
+
+    fn ask(&self, _ask: Ask) -> Reply {
+        Reply {
+            ok: true,
+            output: json!({}),
+            latency_ms: 0,
+            cost: json!({}),
+        }
+    }
+}
+
+#[test]
+fn mcp_tool_from_config_invokes() {
+    let server = MockServer::start();
+    let _handshake = server.mock(|when, then| {
+        when.method(POST)
+            .json_body_partial(json!({"method": "handshake"}).to_string());
+        then.status(200)
+            .json_body(json!({"jsonrpc":"2.0","id":1,"result":{"ok":true}}));
+    });
+    let _schema = server.mock(|when, then| {
+        when.method(POST)
+            .json_body_partial(json!({"method": "schema"}).to_string());
+        then.status(200)
+            .json_body(json!({"jsonrpc":"2.0","id":2,"result":{}}));
+    });
+    let _invoke = server.mock(|when, then| {
+        when.method(POST)
+            .json_body_partial(json!({"method": "invoke"}).to_string());
+        then.status(200)
+            .json_body(json!({"jsonrpc":"2.0","id":3,"result":"pong"}));
+    });
+
+    let cfg_path = std::env::temp_dir().join("mcp_cfg.json");
+    std::fs::write(&cfg_path, format!("{{\"ping\": \"{}\"}}", server.url("/"))).unwrap();
+
+    let mut agent = Agent::new(Dummy, 1, 1000, 1, CancellationToken::new());
+    agent
+        .register_tool("cfg", ToolSpec::McpConfigFile(cfg_path))
+        .unwrap();
+
+    assert!(agent.has_tool("ping"));
+    let reply = agent
+        .call_tool(
+            "ping",
+            Ask {
+                op: "ping".into(),
+                input: json!({}),
+                context: json!({}),
+            },
+        )
+        .unwrap();
+    assert_eq!(reply.output, json!("pong"));
+
+    _handshake.assert();
+    _schema.assert();
+    _invoke.assert();
+}


### PR DESCRIPTION
## Summary
- add `mcp_client` crate for JSON-RPC handshake, schema fetch and invoke
- implement `McpProvider` and `ToolSpec` with config-based registration
- document MCP server configuration and add integration test

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68c65e3e8e40832487d8286295f68c7e